### PR TITLE
Feat/#1

### DIFF
--- a/Layout/MainLayout.tsx
+++ b/Layout/MainLayout.tsx
@@ -14,6 +14,7 @@ export default MainLayout;
 
 const StWrapper = styled.main`
   width: 100%;
+  margin-top: 10rem;
 
   display: flex;
   justify-content: center;

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
+import styled from 'styled-components';
 
 const Header = () => {
-  return <div>헤더입니다</div>;
+  return <StWrapper>깃허브 맞팔 탐지기</StWrapper>;
 };
 
 export default Header;
+
+const StWrapper = styled.header`
+  width: 100%;
+  padding: 1rem;
+
+  background-color: ${({ theme }) => theme.colors.green};
+`;

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  compiler: {
+    styledComponents: true,
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,12 +1,16 @@
 import type { AppProps } from 'next/app';
 import GlobalStyle from '../styles/globalStyles';
 import { RecoilRoot } from 'recoil';
+import { ThemeProvider } from 'styled-components';
+import theme from '../styles/theme';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <RecoilRoot>
-      <GlobalStyle />
-      <Component {...pageProps} />
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <Component {...pageProps} />
+      </ThemeProvider>
     </RecoilRoot>
   );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,15 +1,42 @@
-//ssr이라 처음에는 스타일이 아무것도 안된 html만 보이니까 미리 초기 스타일을 지정해주는 파일!
-import { Html, Head, Main, NextScript } from 'next/document';
+import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
 
-export default function Document() {
-  return (
-    <Html lang="en">
-      <Head />
-      <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-      <body>
-        <Main />
-        <NextScript />
-      </body>
-    </Html>
-  );
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+        });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
 }
+
+export default MyDocument;

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -21,3 +21,5 @@ const colors = {
 const theme: DefaultTheme = {
   colors,
 };
+
+export default theme;


### PR DESCRIPTION
## 🔥 Related Issues

close #1 

## 💜 작업 내용

- [x] ~ styled-components 클래스명 맞추는 오류를 수정했습니다.
- [x] ~ theme.ts 파일 export을 안해놔서 적용이 안되던 사소한 이슈를 해결했습니다
- [x] ~ 헤더 퍼블리싱을 했습니다.
- [x] ~ 메인 레이아웃과 헤더 사이에 마진을 적용했습니다.  


## 😡 Trouble Shooting
- styled-components 클래스명 맞추는 오류를 수정했습니다.
- Next.js에서 첫 페이지 로드는 SSR로 동작하기 때문에 서버에서 생성된 컴포넌트와 클라이언트에서 생성된 컴포넌트의 클래스명이 달라져서 생기는 문제라고 합니다.

### ✅ 해결방법
- _document.tsx 파일에서 SSR이 될 때 CSS가 head에 주입 될 수 있도록 해주었습니다.
- Next.js 12 버전부터 babel 대신 swc를 사용하여 컴파일이 되기 때문에 next.config.js에서 설정을 바꿔줬습니다.

<img width="948" alt="스크린샷 2023-06-10 오후 10 20 50" src="https://github.com/SOPT-EEWEBS/follow-detector/assets/69576360/c48d1900-a80a-42a6-a418-98a218196748">


## 👀 스크린샷 / GIF / 링크

## 📚 Reference
- [swc란?](https://velog.io/@seohyeon1578/NextJS-SWC-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)

